### PR TITLE
Fix the 'copy' task.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ dist/
 
 # Backups
 *.zip
+
+# Gradle cache
+.gradle/

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ plugins {
     id "java"
     id "eclipse"
     id "idea"
-    id "jaci.openrio.gradle.GradleRIO" //version "2018.03.06"
+    id "jaci.openrio.gradle.GradleRIO" version "2018.03.06"
 }
 
 def TEAM = 4450
@@ -36,9 +36,10 @@ jar {
     //manifest jaci.openrio.gradle.GradleRIOPlugin.javaManifest(ROBOT_CLASS)
 }
 
-task copy(type: Copy) {
-    from file("build/libs/Pathfinder-Java-1.8.jar")
-    into file("C:/Users/rcorn/wpilib/user/RobotLib/Pathfinder-Java-1.8.jar")
+task buildToRobotLib(type: Copy, dependsOn: jar) {
+    mkdir System.getProperty("user.home") + "\\wpilib\\user\\RobotLib"
+    from 'build\\libs\\Pathfinder-Java.jar'
+    into System.getProperty("user.home") + "\\wpilib\\user\\RobotLib"
 }
 
 task wrapper(type: Wrapper) {


### PR DESCRIPTION
Changes List:
- Fixed GradleRio plugin declaration
- Renamed 'copy' task to a more descriptive 'buildToRobotLib'
- Made 'buildToRobotLib' task depend on 'jar' task. (Making sure jar was built before copying)
- Made sure RobotLib folder existed
- Fixed from path. (Jar was named 'Pathfinder-Java.jar' instead of 'Pathfinder-Java-1.8.jar')
- Made the into path use the 'user.home' property
- Added '.gradle' directory to .gitignore